### PR TITLE
Can associate an external object w/ world objects

### DIFF
--- a/shapes-demo/src/Physics/Demo/Contact.hs
+++ b/shapes-demo/src/Physics/Demo/Contact.hs
@@ -29,13 +29,13 @@ import Utils.Utils
 
 class (ToCanonical (CDOverlap e), ToCanonical (PEConvexHull e), PhysicsEngine e, Canonical (CDOverlap e) ~ Overlap, Canonical (PEConvexHull e) ~ Polygon) => ContactDemo e where
   type CDOverlap e
-  makeBox :: Proxy e -> V2' -> Double -> (Double, Double) -> PEWorldObj e
+  makeBox :: Proxy e -> V2' -> Double -> (Double, Double) -> PEWorldObj e ()
   checkOverlap :: Proxy e -> PEConvexHull e -> PEConvexHull e -> Maybe (CDOverlap e)
   checkContact :: Proxy e -> PEConvexHull e -> PEConvexHull e -> (Maybe (Flipping Contact), Maybe (CDOverlap e), Maybe (CDOverlap e))
   penetratingEdge :: Proxy e -> CDOverlap e -> (P2 Double, P2 Double)
   penetratedEdge :: Proxy e -> CDOverlap e -> (P2 Double, P2 Double)
-  generateContacts :: Proxy e -> PEWorldObj e -> PEWorldObj e -> [Contact]
-  objHull :: Proxy e -> PEWorldObj e -> PEConvexHull e
+  generateContacts :: Proxy e -> PEWorldObj e () -> PEWorldObj e () -> [Contact]
+  objHull :: Proxy e -> PEWorldObj e () -> PEConvexHull e
 
 data DemoState =
   DemoState { _testFinished :: Bool
@@ -44,10 +44,10 @@ data DemoState =
             }
 makeLenses ''DemoState
 
-boxA :: (ContactDemo e) => Proxy e -> DemoState -> PEWorldObj e
+boxA :: (ContactDemo e) => Proxy e -> DemoState -> PEWorldObj e ()
 boxA p _ = makeBox p (V2 0 0) 0 (4, 4)
 
-boxB :: (ContactDemo e) => Proxy e -> DemoState -> PEWorldObj e
+boxB :: (ContactDemo e) => Proxy e -> DemoState -> PEWorldObj e ()
 boxB p (DemoState _ posB angleB) = makeBox p posB angleB (2, 2)
 
 vt :: M33 Double
@@ -81,7 +81,7 @@ contactTest p r sa sb = do
         drawC = either f f
           where f = drawContact r . transform vt
 
-contactTest' :: (ContactDemo e) => Proxy e -> R.Renderer -> PEWorldObj e -> PEWorldObj e -> IO ()
+contactTest' :: (ContactDemo e) => Proxy e -> R.Renderer -> PEWorldObj e () -> PEWorldObj e () -> IO ()
 contactTest' p r a b = do
   setColor r cyan
   mapM_ f contacts

--- a/shapes-demo/src/Physics/Demo/IOWorld.hs
+++ b/shapes-demo/src/Physics/Demo/IOWorld.hs
@@ -32,7 +32,7 @@ import Utils.Utils
 import Physics.Scenes.Scene
 import Physics.Demo.Scenes
 
-class (PhysicsEngine e, MonadIO (DemoM e)) => Demo e where
+class (PhysicsEngine e, PEExternalObj e ~ (), MonadIO (DemoM e)) => Demo e where
   type DemoM e :: * -> *
   runDemo :: Proxy e -> Scene e -> DemoM e a -> IO a
   resetEngine :: Proxy e -> Scene e -> DemoM e ()

--- a/shapes-demo/src/Physics/Demo/OptContact.hs
+++ b/shapes-demo/src/Physics/Demo/OptContact.hs
@@ -1,32 +1,33 @@
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash         #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 module Physics.Demo.OptContact where
 
-import Control.Lens
+import           Control.Lens
 
-import qualified Linear.V2 as L
+import qualified Linear.V2                  as L
 
-import Physics.Linear.Convert
-import qualified Physics.Contact as S
-import Physics.Contact.ConvexHull
-import qualified Physics.Contact.SAT as S
-import Physics.Engine.Class
-import Physics.Engine
-import Physics.World.Class
-import qualified Physics.World.Object as S
+import qualified Physics.Contact            as S
+import           Physics.Contact.ConvexHull
+import qualified Physics.Contact.SAT        as S
+import           Physics.Engine
+import           Physics.Engine.Class
+import           Physics.Linear.Convert
+import           Physics.World.Class
+import qualified Physics.World.Object       as S
 
-import Physics.Draw.Canonical
-import Physics.Draw.Opt()
-import Physics.Demo.Contact (ContactDemo(..))
+import           Physics.Demo.Contact       (ContactDemo (..))
+import           Physics.Draw.Canonical
+import           Physics.Draw.Opt           ()
 
-import Utils.Descending
-import Utils.Utils
+import           Utils.Descending
+import           Utils.Utils
 
-instance ContactDemo Engine where
-  type CDOverlap Engine = S.Overlap
+instance ContactDemo (Engine ()) where
+  type CDOverlap (Engine ()) = S.Overlap
   makeBox p (L.V2 x y) rot (w, h) =
-    makeWorldObj p phys 0.2 (makeRectangleHull p w h)
+    makeWorldObj p phys 0.2 (makeRectangleHull p w h) ()
     where phys = makePhysicalObj p (0, 0) 0 (x, y) rot (1, 1)
   checkOverlap _ sa sb = S.minOverlap' sa sb ^? S._MinOverlap
   checkContact _ sa sb =

--- a/shapes-demo/src/Physics/Demo/OptWorld.hs
+++ b/shapes-demo/src/Physics/Demo/OptWorld.hs
@@ -1,33 +1,34 @@
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 module Physics.Demo.OptWorld where
 
-import Control.Lens
-import Control.Monad
-import Control.Monad.Reader
-import Control.Monad.ST
-import Control.Monad.State.Strict
-import qualified Data.Vector.Unboxed as V
-import Data.Maybe
+import           Control.Lens
+import           Control.Monad
+import           Control.Monad.Reader
+import           Control.Monad.ST
+import           Control.Monad.State.Strict
+import           Data.Maybe
+import qualified Data.Vector.Unboxed        as V
 
-import qualified Physics.Broadphase.Aabb as B
-import Physics.Contact
-import Physics.Contact.ConvexHull
-import Physics.Engine
-import qualified Physics.Engine.Main as OM
-import Physics.World.Class
-import Physics.Scenes.Scene
+import qualified Physics.Broadphase.Aabb    as B
+import           Physics.Contact
+import           Physics.Contact.ConvexHull
+import           Physics.Engine
+import qualified Physics.Engine.Main        as OM
+import           Physics.Scenes.Scene
+import           Physics.World.Class
 
-import Physics.Draw.Canonical
-import qualified Physics.Draw.Opt as D
-import Physics.Demo.IOWorld (Demo(..))
+import           Physics.Demo.IOWorld       (Demo (..))
+import           Physics.Draw.Canonical
+import qualified Physics.Draw.Opt           as D
 
-import Utils.Descending
-import Utils.Utils
+import           Utils.Descending
+import           Utils.Utils
 
-instance Demo Engine where
-  type DemoM Engine = ReaderT OM.EngineConfig (StateT (OM.EngineState RealWorld) IO)
+instance Demo (Engine ()) where
+  type DemoM (Engine ()) = ReaderT OM.EngineConfig (StateT (OM.EngineState () RealWorld) IO)
   runDemo _ scene@Scene{..} action = do
     eState <- liftIO . stToIO $ OM.initEngine scene
     evalStateT (runReaderT action eConfig) eState
@@ -53,6 +54,6 @@ instance Demo Engine where
   debugEngineState _ = return "<insert debug trace here>"
   updateWorld _ = void . convertEngineT $ OM.updateWorld
 
-convertEngineT :: OM.EngineST RealWorld a -> DemoM Engine a
+convertEngineT :: OM.EngineST () RealWorld a -> DemoM (Engine ()) a
 convertEngineT action =
   ReaderT (\config -> StateT (\state -> stToIO $ runStateT (runReaderT action config) state))

--- a/shapes-demo/src/Physics/Demo/Scenes.hs
+++ b/shapes-demo/src/Physics/Demo/Scenes.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 module Physics.Demo.Scenes where
 
 import Data.Proxy
@@ -11,9 +12,17 @@ import qualified Physics.Scenes.FourBoxesTwoStatic as S1
 import qualified Physics.Scenes.Rolling as S2
 import qualified Physics.Scenes.Stacks as S3
 
-scenes :: (PhysicsEngine e) => Proxy e -> [Scene e]
-scenes p =
-  [S3.makeScene (30, 30) 1, S1.scene, S1.scene', S2.scene, S3.scene, S3.scene', S3.scene'', S3.scene''', S0.scene] <*> pure p
+scenes :: (PhysicsEngine e, PEExternalObj e ~ ()) => Proxy e -> [Scene e]
+scenes p = [ S3.makeScene (30, 30) 1 p ()
+           , S1.scene p () () () ()
+           , S1.scene' p () () () ()
+           , S2.scene p () ()
+           , S3.scene p ()
+           , S3.scene' p ()
+           , S3.scene'' p ()
+           , S3.scene''' p ()
+           , S0.scene p () ()
+           ]
 
 nextScene :: Int -> [a] -> (Int, a)
 nextScene i ss = (i', ss !! i')

--- a/shapes-demo/src/Physics/Draw/Opt.hs
+++ b/shapes-demo/src/Physics/Draw/Opt.hs
@@ -80,5 +80,5 @@ drawObj :: R.Renderer -> L.M33 Double -> ConvexHull -> IO ()
 drawObj r viewtrans hull =
   drawConvexHull r (transform viewtrans . toCanonical $ hull)
 
-drawWorld :: R.Renderer -> L.M33 Double -> World WorldObj -> IO ()
+drawWorld :: R.Renderer -> L.M33 Double -> World (WorldObj ()) -> IO ()
 drawWorld r vt w = sequenceOf_ traverse (fmap (drawObj r vt . _worldShape) (w ^. worldObjs))

--- a/shapes/bench/Main.hs
+++ b/shapes/bench/Main.hs
@@ -34,6 +34,6 @@ main :: IO ()
 -- 770ms simple 3x
 -- 310ms opt+hashtable 3x
 --  80ms opt+vector 2x
-main = defaultMain [bench "opt updateWorld 10" $ nf (OM.runWorld 0.01 (Stacks.makeScene (15, 15) 0 OM.engineP)) 10]
+main = defaultMain [bench "opt updateWorld 10" $ nf (OM.runWorld 0.01 (Stacks.makeScene (15, 15) 0 OM.engineP ())) 10]
 --main = print . rnf $ OM.runWorld 0.01 (Stacks.makeScene (15, 15) 0 OM.engineP) 200
 --main = BB.main

--- a/shapes/bench/Physics/Broadphase/Benchmark.hs
+++ b/shapes/bench/Physics/Broadphase/Benchmark.hs
@@ -48,9 +48,9 @@ testOptAabb a b = SP (SP boxA boxB) (OB.aabbCheck boxA boxB)
   where boxA = OB.toAabb a
         boxB = OB.toAabb b
 
-testWorld :: World WorldObj
+testWorld :: World (WorldObj ())
 testWorld =
-  makeWorld engineP $ stacks engineP (0.2, 0.2) (0, -4.5) (0, 0) 0 (30, 30)
+  makeWorld engineP $ stacks engineP (0.2, 0.2) (0, -4.5) (0, 0) 0 (30, 30) ()
 
 benchy :: [Benchmark]
 benchy = [ bench "opt aabb" $ whnf (uncurry testOptAabb) testOptBoxes

--- a/shapes/src/Physics/Broadphase/Aabb.hs
+++ b/shapes/src/Physics/Broadphase/Aabb.hs
@@ -136,7 +136,7 @@ unorderedPairs n
 -- | Find pairs of objects with overlapping AABBs.
 -- Note: Pairs of static objects are excluded.
 -- These pairs are in descending order according to 'unorderedPairs', where \"ascending\" is the world's traversal order.
-culledKeys :: (V.Unbox k, PhysicsWorld k w o, WorldObj ~ o) => w -> Descending (k, k)
+culledKeys :: (V.Unbox k, PhysicsWorld k w o, WorldObj a ~ o) => w -> Descending (k, k)
 culledKeys w = Descending . catMaybes $ fmap f ijs
   where taggedAabbs = toTaggedAabbs isStatic w
         ijs = unorderedPairs $ V.length taggedAabbs

--- a/shapes/src/Physics/Engine.hs
+++ b/shapes/src/Physics/Engine.hs
@@ -20,21 +20,22 @@ import Physics.Contact.ConvexHull (ConvexHull, rectangleHull, listToHull)
 import Physics.World.External (constantAccel)
 import Physics.Linear (V2(..), P2(..))
 
-data Engine
+data Engine a
 
-engineP :: Proxy Engine
+engineP :: Proxy (Engine a)
 engineP = Proxy
 
 pairToV2 :: (Double, Double) -> V2
 pairToV2 (D# x, D# y) = V2 x y
 
-instance PhysicsEngine Engine where
-  type PEWorld Engine = World
-  type PEWorldObj Engine = WorldObj
-  type PEPhysicalObj Engine = PhysicalObj
-  type PEContactBehavior Engine = ContactBehavior
-  type PENumber Engine = Double
-  type PEConvexHull Engine = ConvexHull
+instance PhysicsEngine (Engine a) where
+  type PEWorld (Engine a)           = World
+  type PEWorldObj (Engine a)        = WorldObj
+  type PEPhysicalObj (Engine a)     = PhysicalObj
+  type PEExternalObj (Engine a)     = a
+  type PEContactBehavior (Engine a) = ContactBehavior
+  type PENumber (Engine a)          = Double
+  type PEConvexHull (Engine a)      = ConvexHull
 
   makePhysicalObj _ vel rotvel pos rotpos =
     PhysicalObj (pairToV2 vel) rotvel (pairToV2 pos) rotpos . toInvMass2

--- a/shapes/src/Physics/Engine/Class.hs
+++ b/shapes/src/Physics/Engine/Class.hs
@@ -13,29 +13,44 @@ import Physics.World.Class
 
 class (Fractional (PENumber e)) => PhysicsEngine e where
   type PEWorld e :: * -> *
-  type PEWorldObj e :: *
-  type PEPhysicalObj e :: *
-  type PEContactBehavior e :: *
-  type PENumber e :: *
-  type PEConvexHull e :: *
+  type PEWorldObj e :: * -> *
+  type PEExternalObj e
+  type PEPhysicalObj e
+  type PEContactBehavior e
+  type PENumber e
+  type PEConvexHull e
 
-  -- vel, rotvel, pos, rotpos, mass
+  -- | Create a @PEPhysicalObj e@.
   makePhysicalObj :: Proxy e
                   -> (PENumber e, PENumber e)
+                  -- ^ Velocity
                   -> PENumber e
+                  -- ^ Rotational velocity
                   -> (PENumber e, PENumber e)
+                  -- ^ Position
                   -> PENumber e
+                  -- ^ Rotation
                   -> (PENumber e, PENumber e)
+                  -- ^ Linear mass paired with rotational mass
                   -> PEPhysicalObj e
+
+  -- | Create a @PEWorldObj e@
   makeWorldObj :: Proxy e
                -> PEPhysicalObj e
+               -- ^ The physical body of this object.
                -> PENumber e
+               -- ^ Coefficient of friction μ (mu).
                -> PEConvexHull e
-               -> PEWorldObj e
-  makeWorld :: Proxy e -> [PEWorldObj e] -> PEWorld' e
+               -- ^ The shape of the object.
+               -> PEExternalObj e
+               -- ^ Any userland piece of data from outside the simulation.
+               -> PEWorldObj e (PEExternalObj e)
+
+  makeWorld :: Proxy e -> [PEWorldObj e (PEExternalObj e)] -> PEWorld' e
   makeContactBehavior :: Proxy e -> PENumber e -> PENumber e -> PEContactBehavior e
   makeConstantAccel :: Proxy e -> (PENumber e, PENumber e) -> External
   makeHull :: Proxy e -> [(PENumber e, PENumber e)] -> PEConvexHull e
   makeRectangleHull :: Proxy e -> PENumber e -> PENumber e -> PEConvexHull e
 
-type PEWorld' e = PEWorld e (PEWorldObj e)
+type PEWorldObj' e = PEWorldObj e (PEExternalObj e)
+type PEWorld' e = PEWorld e (PEWorldObj' e)

--- a/shapes/src/Physics/Engine/Main.hs
+++ b/shapes/src/Physics/Engine/Main.hs
@@ -30,51 +30,51 @@ import Physics.Solvers.Contact
 import Physics.Engine
 import Physics.Scenes.Scene
 
-type World' = World WorldObj
+type World' a = World (WorldObj a)
 
 type EngineCache s = V.MVector s (ObjectFeatureKey Int, ContactResult Lagrangian)
-type EngineState s = (World', EngineCache s, [External])
+type EngineState a s = (World' a, EngineCache s, [External])
 data EngineConfig =
   EngineConfig { _engineTimestep :: Double
                , _engineContactBeh :: ContactBehavior
                } deriving Show
-type EngineST s = ReaderT EngineConfig (StateT (EngineState s) (ST s))
+type EngineST a s = ReaderT EngineConfig (StateT (EngineState a s) (ST s))
 
-initEngine :: Scene Engine -> ST s (EngineState s)
+initEngine :: Scene (Engine a) -> ST s (EngineState a s)
 initEngine Scene{..} = do
   cache <- MV.new 0
   return (_scWorld, cache, _scExts)
 
-changeScene :: Scene Engine -> EngineST s ()
+changeScene :: Scene (Engine a) -> EngineST a s ()
 changeScene scene = do
   eState <- lift . lift $ initEngine scene
   put eState
 
 -- TODO: can I do this with _1?
 wrapUpdater :: V.Vector (ContactResult Constraint)
-            -> (EngineCache s -> V.Vector (ContactResult Constraint) -> World' -> ST s World')
-            -> EngineST s ()
+            -> (EngineCache s -> V.Vector (ContactResult Constraint) -> World' a -> ST s (World' a))
+            -> EngineST a s ()
 wrapUpdater constraints f = do
   (world, cache, externals) <- get
   world' <- lift . lift $ f cache constraints world
   put (world', cache, externals)
 
-wrapUpdater' :: (World' -> ST s World') -> EngineST s World'
+wrapUpdater' :: (World' a -> ST s (World' a)) -> EngineST a s (World' a)
 wrapUpdater' f = do
   (world, cache, externals) <- get
   world' <- lift . lift $ f world
   put (world', cache, externals)
   return world'
 
-wrapInitializer :: (EngineCache s -> World' -> ST s (EngineCache s, V.Vector (ContactResult Constraint), World'))
-                -> EngineST s (V.Vector (ContactResult Constraint))
+wrapInitializer :: (EngineCache s -> (World' a) -> ST s (EngineCache s, V.Vector (ContactResult Constraint), (World' a)))
+                -> EngineST a s (V.Vector (ContactResult Constraint))
 wrapInitializer f = do
   (world, cache, externals) <- get
   (cache', constraints, world') <- lift . lift $ f cache world
   put (world', cache', externals)
   return constraints
 
-updateWorld :: EngineST s World'
+updateWorld :: EngineST a s (World' a)
 updateWorld = do
   EngineConfig{..} <- ask
   (world, _, exts) <- get
@@ -87,16 +87,16 @@ updateWorld = do
   void . wrapUpdater' $ return . wAdvance _engineTimestep
   wrapUpdater' $ return . over worldObjs (fmap woUpdateShape)
 
-stepWorld :: Int -> EngineST s World'
+stepWorld :: Int -> EngineST a s (World' a)
 stepWorld steps = do
   replicateM_ steps updateWorld
   view _1 <$> get
 
-runEngineST :: Double -> Scene Engine -> (forall s. EngineST s a) -> a
+runEngineST :: Double -> Scene (Engine a) -> (forall s. EngineST a s b) -> b
 runEngineST dt scene@Scene{..} action = runST $ do
   state' <- initEngine scene
   evalStateT (runReaderT action engineConfig) state'
   where engineConfig = EngineConfig dt _scContactBeh
 
-runWorld :: Double -> Scene Engine -> Int -> World'
+runWorld :: Double -> Scene (Engine a) -> Int -> (World' a)
 runWorld dt scene steps = runEngineST dt scene $ stepWorld steps

--- a/shapes/src/Physics/Scenes/FourBoxesTwoStatic.hs
+++ b/shapes/src/Physics/Scenes/FourBoxesTwoStatic.hs
@@ -20,26 +20,40 @@ boxD p = makePhysicalObj p (0, 0) 0 (-5, -4) 0 (1, 0)
 staticBoxD :: (PhysicsEngine e) => Proxy e -> PEPhysicalObj e
 staticBoxD p = makePhysicalObj p (0, 0) 0 (-5, -4) 0 (0, 0)
 
-boxA' :: (PhysicsEngine e) => Proxy e -> PEWorldObj e
+boxA' :: (PhysicsEngine e) => Proxy e -> PEExternalObj e -> PEWorldObj' e
 boxA' p = makeWorldObj p (boxA p) 0.2 $ makeRectangleHull p 4 4
 
-boxB' :: (PhysicsEngine e) => Proxy e -> PEWorldObj e
+boxB' :: (PhysicsEngine e) => Proxy e -> PEExternalObj e -> PEWorldObj' e
 boxB' p = makeWorldObj p (boxB p) 0.2 $ makeRectangleHull p 2 2
 
-boxC' :: (PhysicsEngine e) => Proxy e -> PEWorldObj e
+boxC' :: (PhysicsEngine e) => Proxy e -> PEExternalObj e -> PEWorldObj' e
 boxC' p = makeWorldObj p (boxC p) 0.2 $ makeRectangleHull p 18 1
 
-boxD' :: (PhysicsEngine e) => Proxy e -> PEWorldObj e
+boxD' :: (PhysicsEngine e) => Proxy e -> PEExternalObj e -> PEWorldObj' e
 boxD' p = makeWorldObj p (boxD p) 0.2 $ makeRectangleHull p 0.4 3
 
-staticBoxD' :: (PhysicsEngine e) => Proxy e -> PEWorldObj e
+staticBoxD' :: (PhysicsEngine e) => Proxy e -> PEExternalObj e -> PEWorldObj' e
 staticBoxD' p = makeWorldObj p (staticBoxD p) 0.2 $ makeRectangleHull p 0.4 3
 
-world :: (PhysicsEngine e) => Proxy e -> PEWorld e (PEWorldObj e)
-world p = makeWorld p [boxA' p, boxB' p, boxC' p, boxD' p]
+world
+  :: (PhysicsEngine e)
+  => Proxy e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEWorld' e
+world p a b c d = makeWorld p [boxA' p a, boxB' p b, boxC' p c, boxD' p d]
 
-world' :: (PhysicsEngine e) => Proxy e -> PEWorld e (PEWorldObj e)
-world' p = makeWorld p [boxA' p, boxB' p, boxC' p, staticBoxD' p]
+world'
+  :: (PhysicsEngine e)
+  => Proxy e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEWorld' e
+world' p a b c d = makeWorld p [boxA' p a, boxB' p b, boxC' p c, staticBoxD' p d]
 
 externals :: (PhysicsEngine e) => Proxy e -> [External]
 externals p = [makeConstantAccel p (0, -2)]
@@ -47,8 +61,22 @@ externals p = [makeConstantAccel p (0, -2)]
 contactBehavior :: (PhysicsEngine e) => Proxy e -> PEContactBehavior e
 contactBehavior p = makeContactBehavior p 0.01 0.02
 
-scene :: (PhysicsEngine e) => Proxy e -> Scene e
-scene p = Scene (world p) (externals p) (contactBehavior p)
+scene
+  :: (PhysicsEngine e)
+  => Proxy e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> Scene e
+scene p a b c d = Scene (world p a b c d) (externals p) (contactBehavior p)
 
-scene' :: (PhysicsEngine e) => Proxy e -> Scene e
-scene' p = Scene (world' p) (externals p) (contactBehavior p)
+scene'
+  :: (PhysicsEngine e)
+  => Proxy e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> Scene e
+scene' p a b c d = Scene (world' p a b c d) (externals p) (contactBehavior p)

--- a/shapes/src/Physics/Scenes/Rolling.hs
+++ b/shapes/src/Physics/Scenes/Rolling.hs
@@ -11,13 +11,13 @@ shapeA p = makePhysicalObj p (0, 0) 0 (0, -6) 0 (0, 0)
 shapeB :: (PhysicsEngine e) => Proxy e -> PEPhysicalObj e
 shapeB p = makePhysicalObj p (0, 0) (-3) (-7, 12) 0 (1, 0.5)
 
-shapeA' :: (PhysicsEngine e) => Proxy e -> PEWorldObj e
+shapeA' :: (PhysicsEngine e) => Proxy e -> PEExternalObj e -> PEWorldObj' e
 shapeA' p = makeWorldObj p (shapeA p) 0.5 $ makeHull p [ (9, -0.5)
                                                        , (-9, 10)
                                                        , (-9, -0.5)
                                                        ]
 
-shapeB' :: (PhysicsEngine e) => Proxy e -> PEWorldObj e
+shapeB' :: (PhysicsEngine e) => Proxy e -> PEExternalObj e -> PEWorldObj' e
 shapeB' p = makeWorldObj p (shapeB p) 0.5 $ makeHull p [ (2, 1)
                                                        , (1, 2)
                                                        , (-1, 2)
@@ -28,8 +28,13 @@ shapeB' p = makeWorldObj p (shapeB p) 0.5 $ makeHull p [ (2, 1)
                                                        , (2, -1)
                                                        ]
 
-world :: (PhysicsEngine e) => Proxy e -> PEWorld e (PEWorldObj e)
-world p = makeWorld p [shapeA' p, shapeB' p]
+world
+  :: (PhysicsEngine e)
+  => Proxy e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEWorld' e
+world p a b = makeWorld p [shapeA' p a, shapeB' p b]
 
 externals :: (PhysicsEngine e) => Proxy e -> [External]
 externals p = [makeConstantAccel p (0, -4)]
@@ -37,5 +42,10 @@ externals p = [makeConstantAccel p (0, -4)]
 contactBehavior :: (PhysicsEngine e) => Proxy e -> PEContactBehavior e
 contactBehavior p = makeContactBehavior p 0.01 0.02
 
-scene :: (PhysicsEngine e) => Proxy e -> Scene e
-scene p = Scene (world p) (externals p) (contactBehavior p)
+scene
+  :: (PhysicsEngine e)
+  => Proxy e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> Scene e
+scene p a b = Scene (world p a b) (externals p) (contactBehavior p)

--- a/shapes/src/Physics/Scenes/Scene.hs
+++ b/shapes/src/Physics/Scenes/Scene.hs
@@ -11,7 +11,7 @@ import Physics.Engine.Class
 import Physics.World.Class
 
 data Scene e =
-  Scene { _scWorld :: PEWorld e (PEWorldObj e)
+  Scene { _scWorld :: PEWorld' e
         , _scExts :: [External]
         , _scContactBeh :: PEContactBehavior e
         }

--- a/shapes/src/Physics/Scenes/TwoFlyingBoxes.hs
+++ b/shapes/src/Physics/Scenes/TwoFlyingBoxes.hs
@@ -13,20 +13,30 @@ boxA p = makePhysicalObj p (1, 0) 0 (-5, 0) 0 (2, 1)
 boxB :: (PhysicsEngine e) => Proxy e -> PEPhysicalObj e
 boxB p = makePhysicalObj p (-4, 0) 0 (5, 2) 0 (1, 0.5)
 
-boxA' :: (PhysicsEngine e) => Proxy e -> PEWorldObj e
+boxA' :: (PhysicsEngine e) => Proxy e -> PEExternalObj e -> PEWorldObj' e
 boxA' p = makeWorldObj p (boxA p) 0.2 $ makeRectangleHull p 4 4
 
-boxB' :: (PhysicsEngine e) => Proxy e -> PEWorldObj e
+boxB' :: (PhysicsEngine e) => Proxy e -> PEExternalObj e -> PEWorldObj' e
 boxB' p = makeWorldObj p (boxB p) 0.2 $ makeRectangleHull p 2 2
 
-world :: (PhysicsEngine e) => Proxy e -> PEWorld e (PEWorldObj e)
-world p = makeWorld p [boxA' p, boxB' p]
+world
+  :: (PhysicsEngine e)
+  => Proxy e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> PEWorld' e
+world p a b = makeWorld p [boxA' p a, boxB' p b]
 
-externals :: (PhysicsEngine e) => Proxy e -> [External]
+externals :: Proxy e -> [External]
 externals _ = []
 
 contactBehavior :: (PhysicsEngine e) => Proxy e -> PEContactBehavior e
 contactBehavior p = makeContactBehavior p 0.01 0.02
 
-scene :: (PhysicsEngine e) => Proxy e -> Scene e
-scene p = Scene (world p) (externals p) (contactBehavior p)
+scene
+  :: (PhysicsEngine e)
+  => Proxy e
+  -> PEExternalObj e
+  -> PEExternalObj e
+  -> Scene e
+scene p a b = Scene (world p a b) (externals p) (contactBehavior p)

--- a/shapes/src/Physics/World/Object.hs
+++ b/shapes/src/Physics/World/Object.hs
@@ -3,8 +3,9 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE RecordWildCards #-}
 
-{- |
-A physical object that can inhabit a physical world.
+{- | A physical object that can inhabit a physical world.
+Contains a field to hold a reference to something outside
+the physical world.
 -}
 module Physics.World.Object where
 
@@ -16,20 +17,21 @@ import Physics.Constraint
 import Physics.Contact.ConvexHull
 import Physics.World.Class
 
-data WorldObj =
-  WorldObj { _worldPhysObj :: !PhysicalObj
-           , _worldObjMu :: !Double
-           , _worldShape :: !ConvexHull
+data WorldObj a =
+  WorldObj { _worldPhysObj  :: !PhysicalObj
+           , _worldObjMu    :: !Double
+           , _worldShape    :: !ConvexHull
+           , _worldUserData :: !a
            } deriving (Generic, NFData)
 makeLenses ''WorldObj
 
-instance Show WorldObj where
-  show (WorldObj obj _ _) = "WorldObj { " ++ show obj ++ " }"
+instance Show (WorldObj a) where
+  show (WorldObj obj _ _ _) = "WorldObj { " ++ show obj ++ " ... }"
 
-instance Physical WorldObj where
+instance Physical (WorldObj a) where
   woPhys = worldPhysObj
 
-instance Contactable WorldObj where
+instance Contactable (WorldObj a) where
   woMu = worldObjMu
   woShape = worldShape
   woMuShape f obj@WorldObj{..} =
@@ -40,6 +42,6 @@ instance Contactable WorldObj where
           {-# INLINE g #-}
   {-# INLINE woMuShape #-}
 
-makeWorldObj :: PhysicalObj -> Double -> ConvexHull -> WorldObj
-makeWorldObj phys mu shape = woUpdateShape $ WorldObj phys mu shape
+makeWorldObj :: PhysicalObj -> Double -> ConvexHull -> a -> WorldObj a
+makeWorldObj phys mu shape = woUpdateShape . WorldObj phys mu shape
 {-# INLINE makeWorldObj #-}


### PR DESCRIPTION
This PR allows associating external objects with objects being simulated by creating a new field in WorldObj and changing the kind of WorldObj to `* -> *`. This change is bubbled up to `Engine` (now `Engine :: * -> *`) and a new type family is added to the `PhysicsEngine` class.