### PR TITLE
broadphase using fixed-dimension sparse grid (IntMap). much faster

### DIFF
--- a/shapes-demo/src/Physics/Demo/OptWorld.hs
+++ b/shapes-demo/src/Physics/Demo/OptWorld.hs
@@ -13,6 +13,7 @@ import           Data.Maybe
 import qualified Data.Vector.Unboxed        as V
 
 import qualified Physics.Broadphase.Aabb    as B
+import qualified Physics.Broadphase.Grid    as G
 import           Physics.Contact
 import           Physics.Contact.ConvexHull
 import           Physics.Engine
@@ -43,7 +44,7 @@ instance Demo (Engine ()) where
     world <- demoWorld p
     let cs :: Descending Contact'
         cs = fmap (flipExtractUnsafe . snd) . join $ generateContacts <$> culledPairs
-        pairKeys = B.culledKeys world
+        pairKeys = G.culledKeys (G.toGrid OM.gridAxes world)
         culledPairs = fmap f pairKeys
         f :: (Int, Int) -> (ConvexHull, ConvexHull)
         f ij = fromJust $ iixView (\k -> wObj k . woShape) ij world

--- a/shapes/bench/Physics/Broadphase/Benchmark.hs
+++ b/shapes/bench/Physics/Broadphase/Benchmark.hs
@@ -5,6 +5,7 @@ module Physics.Broadphase.Benchmark where
 import Criterion.Main
 
 import qualified Physics.Broadphase.Aabb as OB
+import qualified Physics.Broadphase.Grid as G
 import qualified Physics.Contact.ConvexHull as OC
 import Physics.World
 import Physics.World.Object
@@ -53,11 +54,12 @@ testWorld =
   makeWorld engineP $ stacks engineP (0.2, 0.2) (0, -4.5) (0, 0) 0 (30, 30) ()
 
 benchy :: [Benchmark]
-benchy = [ bench "opt aabb" $ whnf (uncurry testOptAabb) testOptBoxes
-         , bench "opt broadphase" $ nf OB.culledKeys testWorld
+--benchy = [ bench "opt aabb" $ whnf (uncurry testOptAabb) testOptBoxes
+benchy = [ bench "brute-force broadphase" $ nf OB.culledKeys testWorld
+         , bench "grid broadphase" $ nf G.culledKeys (G.toGrid axes testWorld)
          ]
+  where axes = (G.GridAxis 20 1 (-10), G.GridAxis 20 1 (-10))
 
 main :: IO ()
 main = do
-  print . uncurry testOptAabb $ testOptBoxes
   defaultMain benchy

--- a/shapes/src/Physics/Broadphase/Aabb.hs
+++ b/shapes/src/Physics/Broadphase/Aabb.hs
@@ -1,10 +1,12 @@
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 
 {- |
 "Aabb" is "Axis-aligned bounding box".
@@ -12,28 +14,33 @@ The "broadphase" of collision detection is a conservative estimate of which bodi
 -}
 module Physics.Broadphase.Aabb where
 
-import GHC.Prim (Double#, (>##), (<##))
-import GHC.Types (Double(D#), isTrue#)
+import           GHC.Generics                 (Generic)
+import           GHC.Prim                     (Double#, (<##), (>##))
+import           GHC.Types                    (Double (D#), isTrue#)
 
-import Control.Lens ((^.), itoListOf)
-import Data.Array (elems)
-import Data.Maybe
-import qualified Data.Vector.Unboxed as V
-import Data.Vector.Unboxed.Deriving
-import Physics.Linear
-import Physics.Contact.ConvexHull
-import qualified Physics.Constraint as C
-import Physics.World.Class
-import Physics.World.Object
+import           Control.DeepSeq
+import           Control.Lens                 (itoListOf, (^.))
+import           Data.Array                   (elems)
+import           Data.Maybe
+import qualified Data.Vector.Unboxed          as V
+import           Data.Vector.Unboxed.Deriving
+import qualified Physics.Constraint           as C
+import           Physics.Contact.ConvexHull
+import           Physics.Linear
+import           Physics.World.Class
+import           Physics.World.Object
 
-import Utils.Descending
+import           Utils.Descending
 
 -- TODO: explore rewrite rules or other alternatives to manually using primops
 
 -- | An interval, bounded above and below
 data Bounds = Bounds { _bmin :: Double# -- ^ lower bound
                      , _bmax :: Double# -- ^ upper bound
-                     }
+                     } deriving (Eq, Generic)
+
+instance NFData Bounds where
+  rnf (Bounds _ _) = ()
 
 derivingUnbox "Bounds"
   [t| Bounds -> (Double, Double) |]
@@ -43,7 +50,7 @@ derivingUnbox "Bounds"
 -- | An axis-aligned bounding box (AABB)
 data Aabb = Aabb { _aabbx :: {-# UNPACK #-} !Bounds -- ^ bounds on x axis
                  , _aabby :: {-# UNPACK #-} !Bounds -- ^ bounds on y axis
-                 }
+                 } deriving (Eq, Generic, NFData)
 
 derivingUnbox "Aabb"
   [t| Aabb -> (Bounds, Bounds) |]

--- a/shapes/src/Physics/Broadphase/Grid.hs
+++ b/shapes/src/Physics/Broadphase/Grid.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE DeriveAnyClass         #-}
+{-# LANGUAGE DeriveGeneric          #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MagicHash              #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE RankNTypes             #-}
+{-# LANGUAGE RecordWildCards        #-}
+{-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE TupleSections          #-}
+{-# LANGUAGE TypeFamilies           #-}
+
+module Physics.Broadphase.Grid where
+
+import           GHC.Generics                 (Generic)
+import           GHC.Types                    (Double (D#))
+
+import           Control.DeepSeq
+import           Control.Lens
+import           Data.Foldable                (foldl')
+import qualified Data.IntMap.Strict           as IM
+import           Data.List                    (sortBy)
+import           Data.Maybe                   (mapMaybe)
+import qualified Data.Vector.Unboxed          as V
+import           Data.Vector.Unboxed.Deriving
+
+import           Physics.Broadphase.Aabb      (Aabb (..), Bounds (..),
+                                               aabbCheck, toTaggedAabbs)
+import qualified Physics.Constraint           as C
+import           Physics.Contact.ConvexHull
+import           Physics.World.Class
+import           Physics.World.Object
+import           Utils.Descending
+import           Utils.Utils
+
+{- |
+The grid is indexed in row-major order:
+
+3 4 5
+0 1 2
+
+(where X is horizontal and Y is vertical)
+
+* The grid is only used for shape queries, so it should only contain AABBs.
+* We may want a reverse-lookup from shape ID to grid squares in the future.
+-}
+data Grid = Grid
+  { _gridSquares :: IM.IntMap (IM.IntMap TaggedAabb)
+  , _gridX       :: !GridAxis
+  , _gridY       :: !GridAxis
+  } deriving (Eq, Show, Generic, NFData)
+
+data GridAxis = GridAxis
+  { _gridLength :: !Int
+  , _gridUnit   :: !Double
+  , _gridOrigin :: !Double
+  } deriving (Eq, Show, Generic, NFData)
+
+data TaggedAabb = TaggedAabb
+  { _taggedStatic :: !Bool
+  , _taggedBox    :: !Aabb
+  } deriving (Eq, Show, Generic, NFData)
+
+makeLenses ''Grid
+makeLenses ''GridAxis
+
+toGrid :: (PhysicsWorld Int w o, WorldObj a ~ o) => (GridAxis, GridAxis) -> w -> Grid
+toGrid axes@(xAxis, yAxis) w = Grid (fromTaggedAabbs axes taggedAabbs) xAxis yAxis
+  where taggedAabbs = toTaggedAabbs isStatic w
+        isStatic WorldObj{..} = C.isStatic $ C._physObjInvMass _worldPhysObj
+
+culledKeys :: Grid -> Descending (Int, Int)
+culledKeys Grid{..} = Descending . uniq . sortBy f . concat $ culledKeys' <$> IM.elems _gridSquares
+  where f x y = case compare x y of LT -> GT
+                                    EQ -> EQ
+                                    GT -> LT
+
+culledKeys' :: IM.IntMap TaggedAabb -> [(Int, Int)]
+culledKeys' square = mapMaybe colliding $ allPairs $ IM.toDescList square
+  where colliding ((_, (TaggedAabb True _)), (_, (TaggedAabb True _))) = Nothing
+        -- ^ Don't check two static shapes for collision.
+        colliding ((a, (TaggedAabb _ boxA)), (b, (TaggedAabb _ boxB)))
+          | aabbCheck boxA boxB = Just (a, b)
+          | otherwise = Nothing
+
+allPairs :: [a] -> [(a, a)]
+allPairs [] = []
+allPairs (x:xs) = f [] x xs
+  where f accumPairs first [] = accumPairs
+        f accumPairs first remaining@(x:xs) = f (foldl' g accumPairs remaining) x xs
+          where g accumPairs x = (first, x):accumPairs
+
+uniq :: Eq a => [a] -> [a]
+uniq [] = []
+uniq (x:[]) = [x]
+uniq (x:y:rest)
+  | x == y = uniq (x:rest)
+  | otherwise = x : uniq (y:rest)
+
+fromTaggedAabbs :: (GridAxis, GridAxis) -> V.Vector (Int, Aabb, Bool) -> IM.IntMap (IM.IntMap TaggedAabb)
+fromTaggedAabbs (x, y) = V.foldl' insertBox IM.empty
+  where
+    insertBox grid (key, box, isStatic) = foldl' insertBoxAt grid indices
+      where
+        indices = boxIndices (x, y) box
+        insertBoxAt grid index =
+          grid & at index . non IM.empty . at key .~ Just taggedBox
+        taggedBox = TaggedAabb isStatic box
+
+-- | Flatten a pair of axial indices to a single grid index.
+flattenIndex :: Grid -> (Int, Int) -> Int
+flattenIndex Grid{..} (x, y) = flattenIndex' _gridX (x, y)
+
+-- | Flatten a pair of axial indices to a single grid index.
+flattenIndex' :: GridAxis -> (Int, Int) -> Int
+flattenIndex' xAxis@GridAxis{..} (x, y) = x + (y * _gridLength)
+
+-- | Flattened grid index of a given point.
+pointIndex :: Grid -> (Double, Double) -> Int
+pointIndex grid@Grid{..} (x, y) = flattenIndex' _gridX (i, j)
+  where i = axialIndex _gridX x
+        j = axialIndex _gridY y
+
+-- | Index along a single axis.
+axialIndex :: GridAxis -> Double -> Int
+axialIndex GridAxis{..} val =
+  floor $ (val - _gridOrigin) / _gridUnit
+
+-- | All flattened grid indices that match a given 'Aabb'.
+boxIndices :: (GridAxis, GridAxis) -> Aabb -> [Int]
+boxIndices (xAxis, yAxis) Aabb {..} = do
+  x <- axisRange _aabbx xAxis
+  y <- axisRange _aabby yAxis
+  return $ flattenIndex' xAxis (x, y)
+  where
+    axisRange (Bounds min max) axis = [minIx .. maxIx]
+      where
+        minIx = axialIndex axis (D# min)
+        maxIx = axialIndex axis (D# max)

--- a/shapes/src/Physics/Engine/Main.hs
+++ b/shapes/src/Physics/Engine/Main.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {- |
@@ -10,35 +10,39 @@ module Physics.Engine.Main ( module Physics.Engine.Main
                            , module Physics.Engine
                            ) where
 
-import Control.Lens
-import Control.Monad.State.Strict
-import Control.Monad.ST
-import Control.Monad.Reader
-import qualified Data.Vector.Unboxed as V
+import           Control.Lens
+import           Control.Monad.Reader
+import           Control.Monad.ST
+import           Control.Monad.State.Strict
 import qualified Data.Vector.Generic.Mutable as MV
+import qualified Data.Vector.Unboxed         as V
 
-import Physics.Broadphase.Aabb
-import Physics.Constraint
-import Physics.Constraints.Contact
-import Physics.Constraints.Types
-import Physics.Contact (ContactBehavior)
-import Physics.World
-import Physics.World.Class
-import Physics.World.Object
-import Physics.Solvers.Contact
+import           Physics.Broadphase.Aabb
+import qualified Physics.Broadphase.Grid     as G
+import           Physics.Constraint
+import           Physics.Constraints.Contact
+import           Physics.Constraints.Types
+import           Physics.Contact             (ContactBehavior)
+import           Physics.Solvers.Contact
+import           Physics.World
+import           Physics.World.Class
+import           Physics.World.Object
 
-import Physics.Engine
-import Physics.Scenes.Scene
+import           Physics.Engine
+import           Physics.Scenes.Scene
 
 type World' a = World (WorldObj a)
 
 type EngineCache s = V.MVector s (ObjectFeatureKey Int, ContactResult Lagrangian)
 type EngineState a s = (World' a, EngineCache s, [External])
 data EngineConfig =
-  EngineConfig { _engineTimestep :: Double
+  EngineConfig { _engineTimestep   :: Double
                , _engineContactBeh :: ContactBehavior
                } deriving Show
 type EngineST a s = ReaderT EngineConfig (StateT (EngineState a s) (ST s))
+
+gridAxes :: (G.GridAxis, G.GridAxis)
+gridAxes = (G.GridAxis 20 1 (-10), G.GridAxis 20 1 (-10))
 
 initEngine :: Scene (Engine a) -> ST s (EngineState a s)
 initEngine Scene{..} = do
@@ -78,7 +82,7 @@ updateWorld :: EngineST a s (World' a)
 updateWorld = do
   EngineConfig{..} <- ask
   (world, _, exts) <- get
-  let keys = culledKeys world
+  let keys = G.culledKeys (G.toGrid gridAxes world)
       kContacts = prepareFrame keys world
   void . wrapUpdater' $ return . wApplyExternals exts _engineTimestep
   constraints <- wrapInitializer $ applyCachedSlns _engineContactBeh _engineTimestep kContacts


### PR DESCRIPTION
New broadphase culling:

1. Insert all objects' AABBs into a grid of fixed dimensions (represented as an IntMap)
2. Check for AABB collisions within each square of the grid.

Limitations:

Fixed grid size and fixed granularity.